### PR TITLE
Compliance with RFC 6962

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ BitTorrent, for example, requires downloading many small pieces of a file from
 many untrusted peers; Merkle proofs allow the downloader to verify that each
 piece is part of the full file.
 
+When sha256 is used as the hashing algorithm, this merkle tree will match the
+merkle tree outlined in RFC 6962, 'Certificate Transparency'.
+
 Usage
 -----
 

--- a/merkletree.go
+++ b/merkletree.go
@@ -164,7 +164,7 @@ func (t *Tree) Push(data []byte) {
 func (t *Tree) Root() (root []byte) {
 	// If the Tree is empty, return nil.
 	if t.head == nil {
-		return nil
+		return sum(t.hash, nil)
 	}
 
 	// The root is formed by hashing together subTrees in order from least in

--- a/merkletree.go
+++ b/merkletree.go
@@ -96,7 +96,7 @@ func (t *Tree) Push(data []byte) {
 	// Hash the data, creating a subTree of height 1.
 	current := &subTree{
 		height: 1,
-		sum:    sum(t.hash, data),
+		sum:    sum(t.hash, append([]byte{0}, data...)),
 	}
 	// Check the height of the next subTree. If the height of the next subTree
 	// is the same as the height of the current subTree, combine the two
@@ -238,7 +238,7 @@ func VerifyProof(h hash.Hash, merkleRoot []byte, proofSet [][]byte, proofIndex u
 	// The first element of the proof set is the original data. Hash it to get
 	// the first level subTree root.
 	height := 0
-	sum := sum(h, proofSet[height])
+	sum := sum(h, append([]byte{0}, proofSet[height]...))
 	height++
 
 	// A proof on a complete tree can be constructed by finding the two

--- a/merkletree.go
+++ b/merkletree.go
@@ -51,10 +51,10 @@ func sum(h hash.Hash, data []byte) []byte {
 	return result
 }
 
-// join takes two byte slices, appends them, hashes them, and then returns the
-// result.
+// join takes two byte slices, appends them, prepends 0x01, hashes them, and
+// then returns the result.
 func join(h hash.Hash, a, b []byte) []byte {
-	return sum(h, append(a, b...))
+	return sum(h, append(append([]byte{1}, a...), b...))
 }
 
 // New initializes a Tree with a hash object, which will be used when hashing
@@ -93,11 +93,12 @@ func (t *Tree) Push(data []byte) {
 		t.proofSet = append(t.proofSet, data)
 	}
 
-	// Hash the data, creating a subTree of height 1.
+	// Prepend the data with 0x00 and hash it, creating a subTree of height 1.
 	current := &subTree{
 		height: 1,
 		sum:    sum(t.hash, append([]byte{0}, data...)),
 	}
+
 	// Check the height of the next subTree. If the height of the next subTree
 	// is the same as the height of the current subTree, combine the two
 	// subTrees to create a subTree with a height that is 1 greater.
@@ -162,7 +163,7 @@ func (t *Tree) Push(data []byte) {
 // Asking for the root when no data has been added will return nil. The tree is
 // left unaltered.
 func (t *Tree) Root() (root []byte) {
-	// If the Tree is empty, return nil.
+	// If the Tree is empty, return the hash of the empty string.
 	if t.head == nil {
 		return sum(t.hash, nil)
 	}
@@ -235,8 +236,8 @@ func VerifyProof(h hash.Hash, merkleRoot []byte, proofSet [][]byte, proofIndex u
 		return false
 	}
 
-	// The first element of the proof set is the original data. Hash it to get
-	// the first level subTree root.
+	// The first element of the proof set is the original data. Prepend it with
+	// 0x00 and hash it to get the first level subTree root.
 	height := 0
 	sum := sum(h, append([]byte{0}, proofSet[height]...))
 	height++

--- a/merkletree_test.go
+++ b/merkletree_test.go
@@ -28,10 +28,9 @@ type MerkleTester struct {
 	*testing.T
 }
 
-// join returns the sha256 hash of a+b.
+// join returns the sha256 hash of 0x01 || a || b.
 func (mt *MerkleTester) join(a, b []byte) []byte {
-	return sum(sha256.New(), append(a, b...))
-	// return sum(sha256.New(), append(append([]byte{1}, a), b...))
+	return sum(sha256.New(), append(append([]byte{1}, a...), b...))
 }
 
 // CreateMerkleTester creates a merkle tester and manually fills out many of

--- a/merkletree_test.go
+++ b/merkletree_test.go
@@ -31,6 +31,7 @@ type MerkleTester struct {
 // join returns the sha256 hash of a+b.
 func (mt *MerkleTester) join(a, b []byte) []byte {
 	return sum(sha256.New(), append(a, b...))
+	// return sum(sha256.New(), append(append([]byte{1}, a), b...))
 }
 
 // CreateMerkleTester creates a merkle tester and manually fills out many of
@@ -54,7 +55,7 @@ func CreateMerkleTester(t *testing.T) (mt *MerkleTester) {
 	}
 
 	// Manually build out expected merkle root values.
-	mt.roots[0] = []byte(nil)
+	mt.roots[0] = sum(sha256.New(), nil)
 	mt.roots[1] = mt.leaves[0]
 	mt.roots[2] = mt.join(mt.leaves[0], mt.leaves[1])
 	mt.roots[3] = mt.join(

--- a/merkletree_test.go
+++ b/merkletree_test.go
@@ -51,7 +51,7 @@ func CreateMerkleTester(t *testing.T) (mt *MerkleTester) {
 		mt.data = append(mt.data, []byte{byte(i)})
 	}
 	for i := 0; i < size; i++ {
-		mt.leaves = append(mt.leaves, sum(sha256.New(), mt.data[i]))
+		mt.leaves = append(mt.leaves, sum(sha256.New(), append([]byte{0}, mt.data[i]...)))
 	}
 
 	// Manually build out expected merkle root values.

--- a/readers.go
+++ b/readers.go
@@ -28,7 +28,8 @@ func readIntoTree(t *Tree, r io.Reader, segmentSize int) error {
 
 // ReaderRoot returns the Merkle root of the data read from the reader, where
 // each leaf is 'segmentSize' long and 'h' is used as the hashing function. All
-// leaves will be 'segmentSize' bytes, the last leaf may have extra zeros.
+// leaves will be 'segmentSize' bytes except the last leaf, which will not be
+// padded out if there are not enough bytes remaining in the reader.
 func ReaderRoot(r io.Reader, h hash.Hash, segmentSize int) (root []byte, err error) {
 	tree := New(h)
 	err = readIntoTree(tree, r, segmentSize)
@@ -41,7 +42,9 @@ func ReaderRoot(r io.Reader, h hash.Hash, segmentSize int) (root []byte, err err
 
 // BuildReaderProof returns a proof that certain data is in the merkle tree
 // created by the data in the reader. The merkle root, set of proofs, and the
-// number of leaves in the Merkle tree are all returned.
+// number of leaves in the Merkle tree are all returned. All leaves will we
+// 'segmentSize' bytes except the last leaf, which will not be padded out if
+// there are not enough bytes remaining in the reader.
 func BuildReaderProof(r io.Reader, h hash.Hash, segmentSize int, index uint64) (root []byte, proofSet [][]byte, numLeaves uint64, err error) {
 	tree := New(h)
 	tree.SetIndex(index)

--- a/readers_test.go
+++ b/readers_test.go
@@ -31,7 +31,7 @@ func TestReaderRootPadding(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedRoot := sum(sha256.New(), []byte{1})
+	expectedRoot := sum(sha256.New(), []byte{0, 1})
 	if bytes.Compare(root, expectedRoot) != 0 {
 		t.Error("ReaderRoot returned the wrong root")
 	}
@@ -43,8 +43,8 @@ func TestReaderRootPadding(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	baseLeft := sum(sha256.New(), []byte{1, 2})
-	baseRight := sum(sha256.New(), []byte{3})
+	baseLeft := sum(sha256.New(), []byte{0, 1, 2})
+	baseRight := sum(sha256.New(), []byte{0, 3})
 	expectedRoot = sum(sha256.New(), append(baseLeft, baseRight...))
 	if bytes.Compare(root, expectedRoot) != 0 {
 		t.Error("ReaderRoot returned the wrong root")
@@ -87,7 +87,7 @@ func TestBuildReaderProofPadding(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedRoot := sum(sha256.New(), []byte{1})
+	expectedRoot := sum(sha256.New(), []byte{0, 1})
 	if bytes.Compare(root, expectedRoot) != 0 {
 		t.Error("ReaderRoot returned the wrong root")
 	}

--- a/readers_test.go
+++ b/readers_test.go
@@ -45,7 +45,7 @@ func TestReaderRootPadding(t *testing.T) {
 
 	baseLeft := sum(sha256.New(), []byte{0, 1, 2})
 	baseRight := sum(sha256.New(), []byte{0, 3})
-	expectedRoot = sum(sha256.New(), append(baseLeft, baseRight...))
+	expectedRoot = sum(sha256.New(), append(append([]byte{1}, baseLeft...), baseRight...))
 	if bytes.Compare(root, expectedRoot) != 0 {
 		t.Error("ReaderRoot returned the wrong root")
 	}


### PR DESCRIPTION
The changes here make package merkletree compliant with the merkle tree outlined in RFC 6962. The changes to the actual code are minor, the tests had to be adjusted a bit more.