### PR TITLE
Fuzzing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+fuzz
 *.swp
 *.out
 *.html
+*.zip

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,28 @@
 all: install
 
+REBUILD:
+	@touch debug*.go
+
+dependencies:
+	go get -u github.com/dvyukov/go-fuzz/go-fuzz
+	go get -u github.com/dvyukov/go-fuzz/go-fuzz-build
+
 install: REBUILD
 	go install
 
 test: REBUILD
-	go test -v -tags=debug -timeout=180s
-test-short: fmt REBUILD
-	go test -short -v -tags=debug -timeout=6s
+	go test -v -tags='debug' -timeout=180s
+test-short: REBUILD
+	go test -short -v -tags='debug' -timeout=6s
 
 cover: REBUILD
-	go test -v -tags=debug -cover -coverprofile=cover.out
+	go test -v -tags='debug' -cover -coverprofile=cover.out
 	go tool cover -html=cover.out -o=cover.html
 	rm cover.out
 
-benchmark: REBUILD
-	go test -v -bench=.
+fuzz: REBUILD
+	go install -tags='debug gofuzz'
+	go-fuzz-build github.com/NebulousLabs/merkletree
+	go-fuzz -bin=./merkletree-fuzz.zip -workdir=fuzz
+
+.PHONY: all REBUILD dependencies install test test-short cover fuzz benchmark

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,37 @@
+// +build gofuzz
+
+package merkletree
+
+import (
+	"bytes"
+	"crypto/sha256"
+)
+
+// Fuzz is called by go-fuzz to look for inputs to BuildReaderProof that will
+// not verify correctly.
+func Fuzz(data []byte) int {
+	// Use the first two bytes to determine the proof index.
+	if len(data) < 2 {
+		return -1
+	}
+	index := 256*uint64(data[0]) + uint64(data[1])
+	data = data[2:]
+
+	// Build a reader proof for index 'index' using the remaining data as input
+	// to the reader. '64' is chosen as the only input size because that is the
+	// size relevant to the Sia project.
+	merkleRoot, proofSet, numLeaves, err := BuildReaderProof(bytes.NewReader(data), sha256.New(), 64, index)
+	if err != nil {
+		return 0
+	}
+	if !VerifyProof(sha256.New(), merkleRoot, proofSet, index, numLeaves) {
+		panic("verification failed!")
+	}
+
+	// Output is more interesting when there is enough data to contain the
+	// index.
+	if uint64(len(data)) > 64*index {
+		return 1
+	}
+	return 0
+}

--- a/merkletree.go
+++ b/merkletree.go
@@ -342,17 +342,6 @@ func VerifyProof(h hash.Hash, merkleRoot []byte, proofSet [][]byte, proofIndex u
 		}
 		stableEnd = subTreeEndIndex
 
-		// Sanity check - the proof index should be between the start and end
-		// index of the subtree (inclusive).
-		if DEBUG {
-			if proofIndex < subTreeStartIndex {
-				panic("weird proof verifying")
-			}
-			if proofIndex > subTreeEndIndex {
-				panic("weird proof verifying")
-			}
-		}
-
 		// Determine if the proofIndex is in the first or the second half of
 		// the subtree.
 		if len(proofSet) <= height {

--- a/merkletree.go
+++ b/merkletree.go
@@ -277,7 +277,7 @@ func VerifyProof(h hash.Hash, merkleRoot []byte, proofSet [][]byte, proofIndex u
 	switch {
 	case merkleRoot == nil:
 		return false
-	case numLeaves == 0:
+	case proofIndex >= numLeaves:
 		return false
 	}
 

--- a/merkletree_test.go
+++ b/merkletree_test.go
@@ -461,6 +461,25 @@ func TestCompatibility(t *testing.T) {
 	}
 }
 
+// TestLeafCounts checks that the number of leaves in the tree are being
+// reported correctly.
+func TestLeafCounts(t *testing.T) {
+	tree := New(sha256.New())
+	tree.SetIndex(0)
+	_, _, _, leaves := tree.Prove()
+	if leaves != 0 {
+		t.Error("bad reporting of leaf count")
+	}
+
+	tree = New(sha256.New())
+	tree.SetIndex(0)
+	tree.Push([]byte{})
+	_, _, _, leaves = tree.Prove()
+	if leaves != 1 {
+		t.Error("bad reporting on leaf count")
+	}
+}
+
 // BenchmarkSha256_4MB uses sha256 to hash 4mb of data.
 func BenchmarkSha256_4MB(b *testing.B) {
 	data := make([]byte, 4*1024*1024)

--- a/readers.go
+++ b/readers.go
@@ -1,6 +1,7 @@
 package merkletree
 
 import (
+	"errors"
 	"hash"
 	"io"
 )
@@ -53,5 +54,9 @@ func BuildReaderProof(r io.Reader, h hash.Hash, segmentSize int, index uint64) (
 		return
 	}
 	root, proofSet, _, numLeaves = tree.Prove()
+	if len(proofSet) == 0 {
+		err = errors.New("index was not reached while creating proof")
+		return
+	}
 	return
 }

--- a/readers_test.go
+++ b/readers_test.go
@@ -101,3 +101,12 @@ func TestBuildReaderProofPadding(t *testing.T) {
 		t.Error("wrong number of leaves returned")
 	}
 }
+
+// TestEmptyReader passes an empty reader into BuildReaderProof.
+func TestEmptyReader(t *testing.T) {
+	reader := bytes.NewReader([]byte{})
+	_, _, _, err := BuildReaderProof(reader, sha256.New(), 64, 5)
+	if err == nil {
+		t.Error(err)
+	}
+}

--- a/readers_test.go
+++ b/readers_test.go
@@ -104,8 +104,7 @@ func TestBuildReaderProofPadding(t *testing.T) {
 
 // TestEmptyReader passes an empty reader into BuildReaderProof.
 func TestEmptyReader(t *testing.T) {
-	reader := bytes.NewReader([]byte{})
-	_, _, _, err := BuildReaderProof(reader, sha256.New(), 64, 5)
+	_, _, _, err := BuildReaderProof(new(bytes.Reader), sha256.New(), 64, 5)
 	if err == nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
While trying out fuzzing, I found an error in the way incomplete proofs are handled when calling ValidProof.

That is now fixed. I also added my fuzzing function to the repo. go-fuzz uses a build tag when it is run, so fuzz.go will not be included during normal compilation.

I am surprised that an error was found so quickly, but it's sort of a delightful thing. The error has been fixed.