### PR TITLE
Export ReadIntoTree

### DIFF
--- a/readers.go
+++ b/readers.go
@@ -6,9 +6,9 @@ import (
 	"io"
 )
 
-// readIntoTree will read segments of size 'segmentSize' and push them into the
-// tree until EOF is reached.
-func readIntoTree(t *Tree, r io.Reader, segmentSize int) error {
+// ReadIntoTree will read segments of size 'segmentSize' and push them into the
+// tree until EOF is reached. Does not pad data.
+func ReadIntoTree(t *Tree, r io.Reader, segmentSize int) error {
 	for {
 		segment := make([]byte, segmentSize)
 		n, readErr := io.ReadFull(r, segment)
@@ -33,7 +33,7 @@ func readIntoTree(t *Tree, r io.Reader, segmentSize int) error {
 // padded out if there are not enough bytes remaining in the reader.
 func ReaderRoot(r io.Reader, h hash.Hash, segmentSize int) (root []byte, err error) {
 	tree := New(h)
-	err = readIntoTree(tree, r, segmentSize)
+	err = ReadIntoTree(tree, r, segmentSize)
 	if err != nil {
 		return
 	}
@@ -49,7 +49,7 @@ func ReaderRoot(r io.Reader, h hash.Hash, segmentSize int) (root []byte, err err
 func BuildReaderProof(r io.Reader, h hash.Hash, segmentSize int, index uint64) (root []byte, proofSet [][]byte, numLeaves uint64, err error) {
 	tree := New(h)
 	tree.SetIndex(index)
-	err = readIntoTree(tree, r, segmentSize)
+	err = ReadIntoTree(tree, r, segmentSize)
 	if err != nil {
 		return
 	}

--- a/readers.go
+++ b/readers.go
@@ -6,9 +6,11 @@ import (
 	"io"
 )
 
-// ReadIntoTree will read segments of size 'segmentSize' and push them into the
-// tree until EOF is reached. Does not pad data.
-func ReadIntoTree(t *Tree, r io.Reader, segmentSize int) error {
+// ReadAll will read segments of size 'segmentSize' and push them into the tree
+// until EOF is reached. Success will return 'err == nil', not 'err == EOF'. No
+// padding is added to the data, so the last element may be smaller than
+// 'segmentSize'.
+func (t *Tree) ReadAll(r io.Reader, segmentSize int) error {
 	for {
 		segment := make([]byte, segmentSize)
 		n, readErr := io.ReadFull(r, segment)
@@ -33,7 +35,7 @@ func ReadIntoTree(t *Tree, r io.Reader, segmentSize int) error {
 // padded out if there are not enough bytes remaining in the reader.
 func ReaderRoot(r io.Reader, h hash.Hash, segmentSize int) (root []byte, err error) {
 	tree := New(h)
-	err = ReadIntoTree(tree, r, segmentSize)
+	err = tree.ReadAll(r, segmentSize)
 	if err != nil {
 		return
 	}
@@ -49,7 +51,7 @@ func ReaderRoot(r io.Reader, h hash.Hash, segmentSize int) (root []byte, err err
 func BuildReaderProof(r io.Reader, h hash.Hash, segmentSize int, index uint64) (root []byte, proofSet [][]byte, numLeaves uint64, err error) {
 	tree := New(h)
 	tree.SetIndex(index)
-	err = ReadIntoTree(tree, r, segmentSize)
+	err = tree.ReadAll(r, segmentSize)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This is to prevent code duplication in the corresponding MerkleTree type
in the Sia crypto package, which reimplimented this functionality in
MerkleTree.ReadSegments. This change will allow MerkleTree.ReadSegments
to wrap ReadIntoTree.

This is being done because the MerkleTree.ReadSegments implementation
had a bug where the last leaf would be padded incorrectly.