### PR TITLE
Reduce allocations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: go
 
 go:
-  - 1.5.3
+  - 1.7
 
 install:
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/kisielk/errcheck
   - go get -u golang.org/x/tools/cmd/cover
-  - go get -u golang.org/x/tools/cmd/vet
   - test -z "$(go fmt)"
   - test -z "$(golint)"
 

--- a/tree.go
+++ b/tree.go
@@ -46,12 +46,15 @@ type subTree struct {
 }
 
 // sum returns the hash of the input data using the specified algorithm.
-func sum(h hash.Hash, data []byte) []byte {
+func sum(h hash.Hash, data ...[]byte) []byte {
 	if data == nil {
 		return nil
 	}
 	h.Reset()
-	h.Write(data) // the Hash interface specifies that Write never returns an error
+	for _, d := range data {
+		// the Hash interface specifies that Write never returns an error
+		_, _ = h.Write(d)
+	}
 	return h.Sum(nil)
 }
 
@@ -59,21 +62,14 @@ func sum(h hash.Hash, data []byte) []byte {
 // sums are calculated using:
 //		Hash(0x00 || data)
 func leafSum(h hash.Hash, data []byte) []byte {
-	h.Reset()
-	h.Write([]byte{0})
-	h.Write(data)
-	return h.Sum(nil)
+	return sum(h, []byte{0}, data)
 }
 
 // nodeSum returns the hash created from two sibling nodes being combined into
 // a parent node. Node sums are calculated using:
 //		Hash(0x01 || left sibling sum || right sibling sum)
 func nodeSum(h hash.Hash, a, b []byte) []byte {
-	h.Reset()
-	h.Write([]byte{1})
-	h.Write(a)
-	h.Write(b)
-	return h.Sum(nil)
+	return sum(h, []byte{1}, a, b)
 }
 
 // joinSubTrees combines two equal sized subTrees into a larger subTree.

--- a/tree.go
+++ b/tree.go
@@ -50,25 +50,30 @@ func sum(h hash.Hash, data []byte) []byte {
 	if data == nil {
 		return nil
 	}
-
-	h.Write(data) // the Hash interface specifies that Write never returns an error
-	result := h.Sum(nil)
 	h.Reset()
-	return result
+	h.Write(data) // the Hash interface specifies that Write never returns an error
+	return h.Sum(nil)
 }
 
 // leafSum returns the hash created from data inserted to form a leaf. Leaf
 // sums are calculated using:
-//		Hash( 0x00 || data)
+//		Hash(0x00 || data)
 func leafSum(h hash.Hash, data []byte) []byte {
-	return sum(h, append([]byte{0}, data...))
+	h.Reset()
+	h.Write([]byte{0})
+	h.Write(data)
+	return h.Sum(nil)
 }
 
 // nodeSum returns the hash created from two sibling nodes being combined into
 // a parent node. Node sums are calculated using:
-//		Hash( 0x01 || left sibling sum || right sibling sum)
+//		Hash(0x01 || left sibling sum || right sibling sum)
 func nodeSum(h hash.Hash, a, b []byte) []byte {
-	return sum(h, append(append([]byte{1}, a...), b...))
+	h.Reset()
+	h.Write([]byte{1})
+	h.Write(a)
+	h.Write(b)
+	return h.Sum(nil)
 }
 
 // joinSubTrees combines two equal sized subTrees into a larger subTree.

--- a/tree.go
+++ b/tree.go
@@ -51,12 +51,7 @@ func sum(h hash.Hash, data []byte) []byte {
 		return nil
 	}
 
-	_, err := h.Write(data)
-	if err != nil {
-		// Result will not be correct if the hash is throwing an error when
-		// it's supposed to be checksumming data.
-		panic(err)
-	}
+	h.Write(data) // the Hash interface specifies that Write never returns an error
 	result := h.Sum(nil)
 	h.Reset()
 	return result

--- a/tree.go
+++ b/tree.go
@@ -47,9 +47,6 @@ type subTree struct {
 
 // sum returns the hash of the input data using the specified algorithm.
 func sum(h hash.Hash, data ...[]byte) []byte {
-	if data == nil {
-		return nil
-	}
 	h.Reset()
 	for _, d := range data {
 		// the Hash interface specifies that Write never returns an error
@@ -243,9 +240,9 @@ func (t *Tree) Push(data []byte) {
 
 // Root returns the Merkle root of the data that has been pushed.
 func (t *Tree) Root() []byte {
-	// If the Tree is empty, return the hash of the empty string.
+	// If the Tree is empty, return nil.
 	if t.head == nil {
-		return sum(t.hash, nil)
+		return nil
 	}
 
 	// The root is formed by hashing together subTrees in order from least in

--- a/tree_test.go
+++ b/tree_test.go
@@ -56,7 +56,7 @@ func CreateMerkleTester(t *testing.T) (mt *MerkleTester) {
 	}
 
 	// Manually build out expected Merkle root values.
-	mt.roots[0] = sum(sha256.New(), nil)
+	mt.roots[0] = nil
 	mt.roots[1] = mt.leaves[0]
 	mt.roots[2] = mt.join(mt.leaves[0], mt.leaves[1])
 	mt.roots[3] = mt.join(
@@ -333,12 +333,6 @@ func TestBuildAndVerifyProof(t *testing.T) {
 // TestBadInputs provides malicious inputs to the functions of the package,
 // trying to trigger panics or unexpected behavior.
 func TestBadInputs(t *testing.T) {
-	// Put nil into sum.
-	a := sum(sha256.New(), nil)
-	if a != nil {
-		t.Error("sum of nil should return nil")
-	}
-
 	// Get the root and proof of an empty tree.
 	tree := New(sha256.New())
 	root := tree.Root()


### PR DESCRIPTION
This change reduces allocations by about 50%. The next step is optimizing the call to `h.Sum`. Currently we always pass `nil`, so a new slice is allocated each time. Ideally we could reuse memory from elsewhere in the tree. This is trivial if we only care about calculating the root (just reuse child memory when calculating the parent hash), but non-trivial when proofs are required. This suggests the possibility of a separate `Root` codepath that is more aggressively optimized. Of course, it would be better if we could apply this optimization when performing proofs as well, but I don't understand `Prove` well enough to attempt it myself.