### PR TITLE
more efficient ReaderRoot algorithm

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -5,6 +5,12 @@ import (
 	"hash"
 )
 
+var (
+	// prefixes used during hashing, as specified by RFC 6962
+	leafHashPrefix = []byte{0}
+	nodeHashPrefix = []byte{1}
+)
+
 // A Tree takes data as leaves and returns the Merkle root. Each call to 'Push'
 // adds one leaf to the Merkle tree. Calling 'Root' returns the Merkle root.
 // The Tree also constructs proof that a single leaf is a part of the tree. The
@@ -59,14 +65,14 @@ func sum(h hash.Hash, data ...[]byte) []byte {
 // sums are calculated using:
 //		Hash(0x00 || data)
 func leafSum(h hash.Hash, data []byte) []byte {
-	return sum(h, []byte{0}, data)
+	return sum(h, leafHashPrefix, data)
 }
 
 // nodeSum returns the hash created from two sibling nodes being combined into
 // a parent node. Node sums are calculated using:
 //		Hash(0x01 || left sibling sum || right sibling sum)
 func nodeSum(h hash.Hash, a, b []byte) []byte {
-	return sum(h, []byte{1}, a, b)
+	return sum(h, nodeHashPrefix, a, b)
 }
 
 // joinSubTrees combines two equal sized subTrees into a larger subTree.


### PR DESCRIPTION
Benchmarks:
```
BenchmarkReader64_1k-4        	  100000	     15137 ns/op	     272 B/op	       7 allocs/op
BenchmarkReader64_4MB-4       	      20	  63088089 ns/op	     656 B/op	      19 allocs/op
BenchmarkReader4k_4MB-4       	     100	  11590328 ns/op	    4496 B/op	      13 allocs/op
BenchmarkReaderTree64_1k-4    	  100000	     19231 ns/op	    3984 B/op	      84 allocs/op
BenchmarkReaderTree64_4MB-4   	      20	  78517088 ns/op	14681616 B/op	  327686 allocs/op
BenchmarkReaderTree4k_4MB-4   	     100	  12885906 ns/op	 4362960 B/op	    5125 allocs/op
```
As it turns out, allocating memory is indeed *really fast!* In the 64_4MB benchmark, the new algorithm eliminated 327667 allocations totaling ~15MB, but was only 15ms faster.