### PR TITLE
Add PushSubTree method to tree.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ go:
 install:
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/kisielk/errcheck
+  - go get -u github.com/NebulousLabs/fastrand
+  - go get -u github.com/NebulousLabs/errors
   - go get -u golang.org/x/tools/cmd/cover
   - test -z "$(go fmt)"
   - test -z "$(golint)"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ REBUILD:
 dependencies:
 	go get -u github.com/dvyukov/go-fuzz/go-fuzz
 	go get -u github.com/dvyukov/go-fuzz/go-fuzz-build
+	go get -u github.com/NebulousLabs/fastrand
+	go get -u github.com/NebulousLabs/errors
 
 install: REBUILD
 	go install

--- a/cachedtree_test.go
+++ b/cachedtree_test.go
@@ -46,7 +46,7 @@ func TestCachedTreeConstruction(t *testing.T) {
 	// tree with no elements.
 	tree := New(sha256.New())
 	cachedTree := NewCachedTree(sha256.New(), 0)
-	if bytes.Compare(tree.Root(), cachedTree.Root()) != 0 {
+	if !bytes.Equal(tree.Root(), cachedTree.Root()) {
 		t.Error("empty Tree and empty CachedTree do not match")
 	}
 
@@ -57,7 +57,7 @@ func TestCachedTreeConstruction(t *testing.T) {
 	tree.Push(arbData[0])
 	subRoot := tree.Root()
 	cachedTree.Push(subRoot)
-	if bytes.Compare(tree.Root(), cachedTree.Root()) != 0 {
+	if !bytes.Equal(tree.Root(), cachedTree.Root()) {
 		t.Error("naive 1-height Tree and CachedTree do not match")
 	}
 
@@ -80,7 +80,7 @@ func TestCachedTreeConstruction(t *testing.T) {
 	tree.Push(arbData[0])
 	tree.Push(arbData[1])
 	tree.Push(arbData[2])
-	if bytes.Compare(tree.Root(), cachedTree.Root()) != 0 {
+	if !bytes.Equal(tree.Root(), cachedTree.Root()) {
 		t.Error("adding 3 len cacheing is causing problems")
 	}
 
@@ -97,7 +97,7 @@ func TestCachedTreeConstruction(t *testing.T) {
 	// Compare against a formally built tree.
 	tree.Push(arbData[0])
 	tree.Push(arbData[1])
-	if bytes.Compare(cachedTree.Root(), tree.Root()) != 0 {
+	if !bytes.Equal(cachedTree.Root(), tree.Root()) {
 		t.Error("comparison has failed")
 	}
 
@@ -114,7 +114,7 @@ func TestCachedTreeConstruction(t *testing.T) {
 	// Compare against a formally built tree.
 	tree.Push(arbData[1]) // Intentional mistake.
 	tree.Push(arbData[1])
-	if bytes.Compare(cachedTree.Root(), tree.Root()) == 0 {
+	if bytes.Equal(cachedTree.Root(), tree.Root()) {
 		t.Error("comparison has succeeded despite mutation")
 	}
 
@@ -148,7 +148,7 @@ func TestCachedTreeConstruction(t *testing.T) {
 	for i := 4; i < 8; i++ {
 		tree.Push(arbData[i])
 	}
-	if bytes.Compare(cachedTree.Root(), tree.Root()) != 0 {
+	if !bytes.Equal(cachedTree.Root(), tree.Root()) {
 		t.Error("comparison has failed")
 	}
 
@@ -333,7 +333,7 @@ func TestCachedTreeConstructionAuto(t *testing.T) {
 				for k := uint64(0); k < i; k++ {
 					subtree := addSubTree(uint64(h), []byte{byte(k)}, j%n, tree)
 					cachedTree.Push(subtree.Root())
-					if bytes.Compare(tree.Root(), cachedTree.Root()) != 0 {
+					if !bytes.Equal(tree.Root(), cachedTree.Root()) {
 						t.Error("naive 1-height Tree and Cached tree roots do not match")
 					}
 

--- a/cachedtree_test.go
+++ b/cachedtree_test.go
@@ -154,16 +154,19 @@ func TestCachedTreeConstruction(t *testing.T) {
 
 	// Try proving on an uninitialized cached tree.
 	cachedTree = NewCachedTree(sha256.New(), 0)
+	cachedTree.SetIndex(0)
 	_, proofSet, _, _ := cachedTree.Prove(nil)
 	if proofSet != nil {
 		t.Error("proving an empty set resulted in a valid proof?")
 	}
 	cachedTree = NewCachedTree(sha256.New(), 1)
+	cachedTree.SetIndex(0)
 	_, proofSet, _, _ = cachedTree.Prove(nil)
 	if proofSet != nil {
 		t.Error("proving an empty set resulted in a valid proof?")
 	}
 	cachedTree = NewCachedTree(sha256.New(), 2)
+	cachedTree.SetIndex(0)
 	_, proofSet, _, _ = cachedTree.Prove(nil)
 	if proofSet != nil {
 		t.Error("proving an empty set resulted in a valid proof?")

--- a/cachedtree_test.go
+++ b/cachedtree_test.go
@@ -154,19 +154,25 @@ func TestCachedTreeConstruction(t *testing.T) {
 
 	// Try proving on an uninitialized cached tree.
 	cachedTree = NewCachedTree(sha256.New(), 0)
-	cachedTree.SetIndex(0)
+	if err := cachedTree.SetIndex(0); err != nil {
+		t.Fatal(err)
+	}
 	_, proofSet, _, _ := cachedTree.Prove(nil)
 	if proofSet != nil {
 		t.Error("proving an empty set resulted in a valid proof?")
 	}
 	cachedTree = NewCachedTree(sha256.New(), 1)
-	cachedTree.SetIndex(0)
+	if err := cachedTree.SetIndex(0); err != nil {
+		t.Fatal(err)
+	}
 	_, proofSet, _, _ = cachedTree.Prove(nil)
 	if proofSet != nil {
 		t.Error("proving an empty set resulted in a valid proof?")
 	}
 	cachedTree = NewCachedTree(sha256.New(), 2)
-	cachedTree.SetIndex(0)
+	if err := cachedTree.SetIndex(0); err != nil {
+		t.Fatal(err)
+	}
 	_, proofSet, _, _ = cachedTree.Prove(nil)
 	if proofSet != nil {
 		t.Error("proving an empty set resulted in a valid proof?")

--- a/fuzz.go
+++ b/fuzz.go
@@ -5,8 +5,6 @@ package merkletree
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/binary"
-	"errors"
 	"io"
 )
 
@@ -52,11 +50,9 @@ func FuzzReadSubTreesWithProof(data []byte) int {
 	tree.SetIndex(index)
 	data = data[2:]
 
-	// 32 is the length of a sha256 hash and 4 bytes are used for the height of
-	// the subTree.
-	subTreeSize := 4 + 36
-	err := tree.readSubTrees(bytes.NewReader(data), subTreeSize)
-	if err != io.ErrUnexpectedEOF {
+	subTreeSize := 1 + 32 // 1 byte height + 32 bytes hash
+	err := tree.readSubTrees(bytes.NewReader(data))
+	if err != nil && err != io.ErrUnexpectedEOF {
 		return 0
 	} else if err == io.ErrUnexpectedEOF && len(data) < subTreeSize {
 		return -1
@@ -84,11 +80,9 @@ func FuzzReadSubTreesWithProof(data []byte) int {
 func FuzzReadSubTreesNoProof(data []byte) int {
 	tree := New(sha256.New())
 
-	// 32 is the length of a sha256 hash and 4 bytes are used for the height of
-	// the subTree.
-	subTreeSize := 4 + 36
-	err := tree.readSubTrees(bytes.NewReader(data), subTreeSize)
-	if err != io.ErrUnexpectedEOF {
+	subTreeSize := 1 + 32 // 1 byte height + 32 bytes hash
+	err := tree.readSubTrees(bytes.NewReader(data))
+	if err != nil && err != io.ErrUnexpectedEOF {
 		return 0
 	} else if err == io.ErrUnexpectedEOF && len(data) < subTreeSize {
 		return -1
@@ -96,8 +90,8 @@ func FuzzReadSubTreesNoProof(data []byte) int {
 	if tree.head != nil && tree.Root() == nil {
 		panic("root shouldn't be nil for a non-empty tree")
 	}
-	// The data is better if it contains many subTrees.
-	if len(data) > 100*subTreeSize {
+	// The data should at least contain 2 subtrees.
+	if len(data) > 2*subTreeSize {
 		return 1
 	}
 	return 0
@@ -105,11 +99,10 @@ func FuzzReadSubTreesNoProof(data []byte) int {
 
 // readSubTrees is a helper function that maps the data from a io.Reader to
 // subTrees and adds them to a tree.
-func (t *Tree) readSubTrees(r io.Reader, subTreeSize int) error {
-	if subTreeSize <= 4 {
-		return errors.New(`the subTree must at least contain 4 bytes for the height
-		plus some data for the sum`)
-	}
+func (t *Tree) readSubTrees(r io.Reader) error {
+	// 32 is the length of a sha256 hash and 1 byte is used for the height of
+	// the subTree.
+	subTreeSize := 1 + 32
 	for {
 		subTree := make([]byte, subTreeSize)
 		_, readErr := io.ReadFull(r, subTree)
@@ -119,9 +112,9 @@ func (t *Tree) readSubTrees(r io.Reader, subTreeSize int) error {
 		} else if readErr != nil {
 			return readErr
 		}
-		// The first 4 bytes of the subTree are mapped to a height in range
-		// [0,50].
-		height := int(binary.LittleEndian.Uint32(subTree[:4])) % 51
+		// The first byte of the subTree are mapped to a height in range
+		// [0,4].
+		height := int(subTree[0]) % 5
 		sum := subTree[4:]
 		if height > 0 {
 			if err := t.PushSubTree(height, sum); err != nil {

--- a/fuzz.go
+++ b/fuzz.go
@@ -82,7 +82,9 @@ func buildAndCompareTreesFromFuzz(data []byte, proofIndex uint64) (cachedTree *T
 	tree := New(hash)
 	cachedTree = New(hash)
 	if proofIndex != math.MaxUint64 {
-		cachedTree.SetIndex(proofIndex)
+		if err := cachedTree.SetIndex(proofIndex); err != nil {
+			panic(err)
+		}
 	}
 
 	for _, b := range data {

--- a/fuzz.go
+++ b/fuzz.go
@@ -109,7 +109,7 @@ func buildAndCompareTreesFromFuzz(data []byte, proofIndex uint64) (cachedTree *T
 			return
 		}
 	}
-	if bytes.Compare(tree.Root(), cachedTree.Root()) != 0 {
+	if !bytes.Equal(tree.Root(), cachedTree.Root()) {
 		panic("tree roots don't match")
 	}
 	return

--- a/fuzz.go
+++ b/fuzz.go
@@ -5,6 +5,9 @@ package merkletree
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"io"
 )
 
 // Fuzz is called by go-fuzz to look for inputs to BuildReaderProof that will
@@ -34,4 +37,95 @@ func Fuzz(data []byte) int {
 		return 1
 	}
 	return 0
+}
+
+// FuzzReadSubTreesWithProof can be used by go-fuzz to test creating a merkle
+// tree from cached subTrees and creating/proving a merkle proof on this tree.
+func FuzzReadSubTreesWithProof(data []byte) int {
+	// Use the first two bytes to determine the proof index.
+	if len(data) < 2 {
+		return -1
+	}
+	// Use the first two bytes to determine the proof index.
+	index := 256*uint64(data[0]) + uint64(data[1])
+	tree := New(sha256.New())
+	tree.SetIndex(index)
+	data = data[2:]
+
+	// 32 is the length of a sha256 hash and 4 bytes are used for the height of
+	// the subTree.
+	subTreeSize := 4 + 36
+	err := tree.readSubTrees(bytes.NewReader(data), subTreeSize)
+	if err != io.ErrUnexpectedEOF {
+		return 0
+	} else if err == io.ErrUnexpectedEOF && len(data) < subTreeSize {
+		return -1
+	}
+
+	// Create and verify the proof.
+	merkleRoot, proofSet, proofIndex, numLeaves := tree.Prove()
+	if !VerifyProof(sha256.New(), merkleRoot, proofSet, proofIndex, numLeaves) {
+		panic("verification failed!")
+	}
+	// Output is more interesting when there is enough data to contain the
+	// index.
+	if uint64(len(data)) > 64*index {
+		return 1
+	}
+	return 0
+}
+
+// FuzzReadSubTreesNoProof can be used by go-fuzz to test creating a merkle
+// tree from cached subTrees.
+func FuzzReadSubTreesNoProof(data []byte) int {
+	tree := New(sha256.New())
+
+	// 32 is the length of a sha256 hash and 4 bytes are used for the height of
+	// the subTree.
+	subTreeSize := 4 + 36
+	err := tree.readSubTrees(bytes.NewReader(data), subTreeSize)
+	if err != io.ErrUnexpectedEOF {
+		return 0
+	} else if err == io.ErrUnexpectedEOF && len(data) < subTreeSize {
+		return -1
+	}
+	if tree.head != nil && tree.Root() == nil {
+		panic("root shouldn't be nil for a non-empty tree")
+	}
+	// The data is better if it contains many subTrees.
+	if len(data) > 100*subTreeSize {
+		return 1
+	}
+	return 0
+}
+
+// readSubTrees is a helper function that maps the data from a io.Reader to
+// subTrees and adds them to a tree.
+func (t *Tree) readSubTrees(r io.Reader, subTreeSize int) error {
+	if subTreeSize <= 4 {
+		return errors.New(`the subTree must at least contain 4 bytes for the height
+		plus some data for the sum`)
+	}
+	for {
+		subTree := make([]byte, subTreeSize)
+		_, readErr := io.ReadFull(r, subTree)
+		if readErr == io.EOF {
+			// All data has been read.
+			break
+		} else if readErr != nil {
+			return readErr
+		}
+		// The first 4 bytes of the subTree are mapped to a height in range
+		// [0,50].
+		height := int(binary.LittleEndian.Uint32(subTree[:4])) % 51
+		sum := subTree[4:]
+		if height > 0 {
+			if err := t.PushSubTree(height, sum); err != nil {
+				return err
+			}
+		} else {
+			t.Push(sum)
+		}
+	}
+	return nil
 }

--- a/fuzz.go
+++ b/fuzz.go
@@ -64,12 +64,16 @@ func FuzzReadSubTreesWithProof(data []byte) int {
 
 	// Create and verify the proof.
 	merkleRoot, proofSet, proofIndex, numLeaves := tree.Prove()
+	if len(proofSet) == 0 {
+		// proofIndex wasn't reached while creating proof.
+		return 0
+	}
 	if !VerifyProof(sha256.New(), merkleRoot, proofSet, proofIndex, numLeaves) {
 		panic("verification failed!")
 	}
 	// Output is more interesting when there is enough data to contain the
 	// index.
-	if uint64(len(data)) > 64*index {
+	if uint64(len(data)) > uint64(subTreeSize)*index {
 		return 1
 	}
 	return 0

--- a/fuzz.go
+++ b/fuzz.go
@@ -10,7 +10,7 @@ import (
 
 // Fuzz is called by go-fuzz to look for inputs to BuildReaderProof that will
 // not verify correctly.
-func FuzzX(data []byte) int {
+func Fuzz(data []byte) int {
 	// Use the first two bytes to determine the proof index.
 	if len(data) < 2 {
 		return -1
@@ -39,7 +39,7 @@ func FuzzX(data []byte) int {
 
 // FuzzReadSubTreesWithProof can be used by go-fuzz to test creating a merkle
 // tree from cached subTrees and creating/proving a merkle proof on this tree.
-func Fuzz(data []byte) int {
+func FuzzReadSubTreesWithProof(data []byte) int {
 	// We want at least 2 bytes for the index and 1 for a subTree.
 	if len(data) < 3 {
 		return -1

--- a/readers_test.go
+++ b/readers_test.go
@@ -16,7 +16,7 @@ func TestReaderRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(root, mt.roots[8]) != 0 {
+	if !bytes.Equal(root, mt.roots[8]) {
 		t.Error("ReaderRoot returned the wrong root")
 	}
 }
@@ -32,7 +32,7 @@ func TestReaderRootPadding(t *testing.T) {
 	}
 
 	expectedRoot := sum(sha256.New(), []byte{0, 1})
-	if bytes.Compare(root, expectedRoot) != 0 {
+	if !bytes.Equal(root, expectedRoot) {
 		t.Error("ReaderRoot returned the wrong root")
 	}
 
@@ -46,7 +46,7 @@ func TestReaderRootPadding(t *testing.T) {
 	baseLeft := sum(sha256.New(), []byte{0, 1, 2})
 	baseRight := sum(sha256.New(), []byte{0, 3})
 	expectedRoot = sum(sha256.New(), append(append([]byte{1}, baseLeft...), baseRight...))
-	if bytes.Compare(root, expectedRoot) != 0 {
+	if !bytes.Equal(root, expectedRoot) {
 		t.Error("ReaderRoot returned the wrong root")
 	}
 }
@@ -61,14 +61,14 @@ func TestBuilReaderProof(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(root, mt.roots[7]) != 0 {
+	if !bytes.Equal(root, mt.roots[7]) {
 		t.Error("BuildReaderProof returned the wrong root")
 	}
 	if len(proofSet) != len(mt.proofSets[7][5]) {
 		t.Fatal("BuildReaderProof returned a proof with the wrong length")
 	}
 	for i := range proofSet {
-		if bytes.Compare(proofSet[i], mt.proofSets[7][5][i]) != 0 {
+		if !bytes.Equal(proofSet[i], mt.proofSets[7][5][i]) {
 			t.Error("BuildReaderProof returned an incorrect proof")
 		}
 	}
@@ -88,13 +88,13 @@ func TestBuildReaderProofPadding(t *testing.T) {
 	}
 
 	expectedRoot := sum(sha256.New(), []byte{0, 1})
-	if bytes.Compare(root, expectedRoot) != 0 {
+	if !bytes.Equal(root, expectedRoot) {
 		t.Error("ReaderRoot returned the wrong root")
 	}
 	if len(proofSet) != 1 {
 		t.Fatal("proofSet is the incorrect length")
 	}
-	if bytes.Compare(proofSet[0], []byte{1}) != 0 {
+	if !bytes.Equal(proofSet[0], []byte{1}) {
 		t.Error("proofSet is incorrect")
 	}
 	if numLeaves != 1 {

--- a/tree_test.go
+++ b/tree_test.go
@@ -245,7 +245,7 @@ func TestBuildRoot(t *testing.T) {
 
 		// Get the root and compare to the manually constructed root.
 		treeRoot := tree.Root()
-		if bytes.Compare(root, treeRoot) != 0 {
+		if !bytes.Equal(root, treeRoot) {
 			t.Error("tree root doesn't match manual root for index", i)
 		}
 	}
@@ -276,7 +276,7 @@ func TestBuildAndVerifyProof(t *testing.T) {
 
 			// Get the proof and check all values.
 			merkleRoot, proofSet, proofIndex, numSegments := tree.Prove()
-			if bytes.Compare(merkleRoot, mt.roots[i]) != 0 {
+			if !bytes.Equal(merkleRoot, mt.roots[i]) {
 				t.Error("incorrect Merkle root returned by Tree for indices", i, j)
 			}
 			if len(proofSet) != len(expectedProveSet) {
@@ -290,7 +290,7 @@ func TestBuildAndVerifyProof(t *testing.T) {
 				t.Error("incorrect numSegments returned for indices", i, j)
 			}
 			for k := range proofSet {
-				if bytes.Compare(proofSet[k], expectedProveSet[k]) != 0 {
+				if !bytes.Equal(proofSet[k], expectedProveSet[k]) {
 					t.Error("proof set does not match expected proof set for indices", i, j, k)
 				}
 			}
@@ -312,14 +312,14 @@ func TestBuildAndVerifyProof(t *testing.T) {
 			// Check that calling Prove a second time results in the same
 			// values.
 			merkleRoot2, proofSet2, proofIndex2, numSegments2 := tree.Prove()
-			if bytes.Compare(merkleRoot, merkleRoot2) != 0 {
+			if !bytes.Equal(merkleRoot, merkleRoot2) {
 				t.Error("tree returned different merkle roots after calling Prove twice for indices", i, j)
 			}
 			if len(proofSet) != len(proofSet2) {
 				t.Error("tree returned different proof sets after calling Prove twice for indices", i, j)
 			}
 			for k := range proofSet {
-				if bytes.Compare(proofSet[k], proofSet2[k]) != 0 {
+				if !bytes.Equal(proofSet[k], proofSet2[k]) {
 					t.Error("tree returned different proof sets after calling Prove twice for indices", i, j)
 				}
 			}
@@ -522,7 +522,7 @@ func TestPushSubTreeCorrectRoot(t *testing.T) {
 	if err := errors.Compose(err1, err2, err3, err4); err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(tree2.Root(), expectedRoot) != 0 {
+	if !bytes.Equal(tree2.Root(), expectedRoot) {
 		t.Fatal("root doesn't match expected root")
 	}
 
@@ -536,7 +536,7 @@ func TestPushSubTreeCorrectRoot(t *testing.T) {
 	if err := errors.Compose(err1, err2); err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(tree3.Root(), expectedRoot) != 0 {
+	if !bytes.Equal(tree3.Root(), expectedRoot) {
 		t.Fatal("root doesn't match expected root")
 	}
 
@@ -547,7 +547,7 @@ func TestPushSubTreeCorrectRoot(t *testing.T) {
 	if err := tree4.PushSubTree(2, node1234Hash); err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(tree4.Root(), expectedRoot) != 0 {
+	if !bytes.Equal(tree4.Root(), expectedRoot) {
 		t.Fatal("root doesn't match expected root")
 	}
 
@@ -560,7 +560,7 @@ func TestPushSubTreeCorrectRoot(t *testing.T) {
 	if err := errors.Compose(err1, err2, err3); err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(tree5.Root(), expectedRoot) != 0 {
+	if !bytes.Equal(tree5.Root(), expectedRoot) {
 		t.Fatal("root doesn't match expected root")
 	}
 
@@ -571,7 +571,7 @@ func TestPushSubTreeCorrectRoot(t *testing.T) {
 	}
 	tree6.Push(leaf3Data)
 	tree6.Push(leaf4Data)
-	if bytes.Compare(tree6.Root(), expectedRoot) != 0 {
+	if !bytes.Equal(tree6.Root(), expectedRoot) {
 		t.Fatal("root doesn't match expected root")
 	}
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -335,7 +335,9 @@ func TestBuildAndVerifyProof(t *testing.T) {
 func TestBadInputs(t *testing.T) {
 	// Get the root and proof of an empty tree.
 	tree := New(sha256.New())
-	tree.SetIndex(0)
+	if err := tree.SetIndex(0); err != nil {
+		t.Fatal(err)
+	}
 	root := tree.Root()
 	if root != nil {
 		t.Error("root of empty tree should be nil")
@@ -517,7 +519,9 @@ func TestPushSubTree(t *testing.T) {
 	// Create a new tree and set the proof index to 1. Afterwards we push twice
 	// to create a subTree of height 1 that contains the proof index.
 	tree2 := New(sha256.New())
-	tree2.SetIndex(1)
+	if err := tree2.SetIndex(1); err != nil {
+		t.Fatal(err)
+	}
 	tree2.Push([]byte{})
 	tree2.Push([]byte{})
 	// Push a subTree of height 1. That should be fine.
@@ -527,7 +531,9 @@ func TestPushSubTree(t *testing.T) {
 	// Create a new tree and set the proof index to 3. Afterwards we push twice
 	// to create a subTree of height 1.
 	tree3 := New(sha256.New())
-	tree3.SetIndex(2)
+	if err := tree3.SetIndex(2); err != nil {
+		t.Fatal(err)
+	}
 	tree3.Push([]byte{})
 	tree3.Push([]byte{})
 	// Push a subTree of height 1. That shouldn't work since the subTree can't
@@ -538,7 +544,9 @@ func TestPushSubTree(t *testing.T) {
 	// Create a new tree and set the proof index to 4. Afterwards we push twice
 	// to create a subTree of height 1.
 	tree4 := New(sha256.New())
-	tree4.SetIndex(3)
+	if err := tree4.SetIndex(3); err != nil {
+		t.Fatal(err)
+	}
 	tree4.Push([]byte{})
 	tree4.Push([]byte{})
 	// Push a subTree of height 1. That shouldn't work since the subTree can't

--- a/verify.go
+++ b/verify.go
@@ -113,7 +113,7 @@ func VerifyProof(h hash.Hash, merkleRoot []byte, proofSet [][]byte, proofIndex u
 	}
 
 	// Compare our calculated Merkle root to the desired Merkle root.
-	if bytes.Compare(sum, merkleRoot) == 0 {
+	if bytes.Equal(sum, merkleRoot) {
 		return true
 	}
 	return false


### PR DESCRIPTION
This PR adds a `PushSubTree` method to the merkle tree that allows us to push cached subtree roots into the tree. Unfortunately the subtree can't contain the element for the proof, that's why I added a `proofTree` bool. If it is set to `true`, the tree won't allow us to push a subTree that contains the element at `proofIndex`. If it is set to `false` we can`t call `Prove` on the tree. 